### PR TITLE
Fb testers

### DIFF
--- a/plugins/Tester/freezeVertex.py
+++ b/plugins/Tester/freezeVertex.py
@@ -23,24 +23,17 @@ class FreezeVertex(medic.PyTester):
         for i in range(plug.numElements()):
             elm = plug.elementByPhysicalIndex(i)
             for j in range(3):
-                if abs(elm.child(j).asDouble()) > sys.float_info.epsilon:
-                    tweaked = True
-                    break
-            if tweaked:
-                break
-            
-        if tweaked:
-            return medic.PyReport(node)
-        else:
-            return None
+                if abs(elm.child(j).asDouble()) > 0.000001:
+                    return medic.PyReport(node)
+
+        return None
 
     def IsFixable(self):
         return True
 
     def fix(self, report, params):
         obj_name = report.node().name()
-
-        cmds.polyMoveVertex(obj_name, ch=1)
+        cmds.polyMoveVertex(obj_name, ch=0)
 
         return True
 

--- a/plugins/Tester/freezeVertex.py
+++ b/plugins/Tester/freezeVertex.py
@@ -1,8 +1,6 @@
 import medic
 from maya import OpenMaya
 from maya import cmds
-import sys
-
 
 class FreezeVertex(medic.PyTester):
     def __init__(self):

--- a/plugins/Tester/intermediateNode.py
+++ b/plugins/Tester/intermediateNode.py
@@ -32,7 +32,11 @@ class IntermediateNode(medic.PyTester):
     def test(self, node):
         if node.dag().isIntermediateObject():
             plugs = OpenMaya.MPlugArray()
-            node.dg().getConnections(plugs)
+            try:
+                node.dg().getConnections(plugs)
+            except:
+                #kfailure:Node has no connections
+                return medic.PyReport(node)
             if plugs.length() <= 2:
                 return medic.PyReport(node)
 

--- a/plugins/Tester/intermediateNode.py
+++ b/plugins/Tester/intermediateNode.py
@@ -30,17 +30,18 @@ class IntermediateNode(medic.PyTester):
 
 
     def test(self, node):
-        if node.dag().isIntermediateObject():
-            plugs = OpenMaya.MPlugArray()
-            try:
-                node.dg().getConnections(plugs)
-            except:
-                #kfailure:Node has no connections
-                return medic.PyReport(node)
-            if plugs.length() <= 2:
-                return medic.PyReport(node)
+        if not node.dag().isIntermediateObject():
+            return None
 
-        return None
+        for i, f in enumerate(cmds.listHistory(node.name(), future=True)) or []:
+            if i == 0:
+                continue
+
+            if "shape" in cmds.nodeType(f, inherited=True):
+                return None
+
+        return medic.PyReport(node)
+       
 
 def Create():
     return IntermediateNode()

--- a/plugins/Tester/shapeNamedAfterTransform.py
+++ b/plugins/Tester/shapeNamedAfterTransform.py
@@ -1,0 +1,57 @@
+import medic
+from maya import OpenMaya
+import re
+from maya import cmds
+
+
+class ShapeNamedAfterTransform(medic.PyTester):
+
+    def __init__(self):
+        super(ShapeNamedAfterTransform, self).__init__()
+
+    def Name(self):
+        return "ShapeNamedAfterTransform"
+
+    def Description(self):
+        return "Shape isn't named after the Transform"
+
+    def Match(self, node):
+        return node.object().hasFn(OpenMaya.MFn.kShape)
+
+    def test(self, node):
+        if node.dag().isInstanced() or node.dag().isFromReferencedFile() or node.dag().isIntermediateObject():
+            return None
+
+        for p in node.parents():
+            correctShapeName = self.NameCompare(node.name(), p.name())
+            if correctShapeName:
+                return None
+
+        return medic.PyReport(node)
+
+    def fix(self, report, params):
+        node = report.node()
+        newName= self.NameCompare(node.name(), node.parents()[0].name(), fixMe=True)
+        cmds.rename(node.name(), newName)
+        return True
+
+    def IsFixable(self):
+        return True
+
+    def NameCompare(self, shape, trans, fixMe=False):
+    
+        tmp_trans = trans.split('|')[-1]
+        tmp_shapeName = tmp_trans + "Shape"
+        shape_lastName = shape.split("|")[-1]
+
+        if fixMe:
+            return shape.replace(shape_lastName, tmp_shapeName)
+
+        if tmp_shapeName != shape_lastName:
+            return False
+        else:
+            return True
+
+def Create():
+    return ShapeNamedAfterTransform()
+    

--- a/plugins/Tester/shapeNamedAfterTransform.py
+++ b/plugins/Tester/shapeNamedAfterTransform.py
@@ -1,7 +1,5 @@
 import medic
 from maya import OpenMaya
-import re
-from maya import cmds
 
 
 class ShapeNamedAfterTransform(medic.PyTester):
@@ -22,35 +20,29 @@ class ShapeNamedAfterTransform(medic.PyTester):
         if node.dag().isInstanced() or node.dag().isFromReferencedFile() or node.dag().isIntermediateObject():
             return None
 
-        for p in node.parents():
-            correctShapeName = self.NameCompare(node.name(), p.name())
-            if correctShapeName:
-                return None
+        parent = node.parents()[0]
+        if ShapeNamedAfterTransform.NameCompare(node.dg().name(), parent.dg().name()):
+            return None
 
         return medic.PyReport(node)
 
     def fix(self, report, params):
         node = report.node()
-        newName= self.NameCompare(node.name(), node.parents()[0].name(), fixMe=True)
-        cmds.rename(node.name(), newName)
+        newName = ShapeNamedAfterTransform.FixName(node.parents()[0].dg().name())
+        node.dg().setName(newName)
         return True
 
     def IsFixable(self):
         return True
 
-    def NameCompare(self, shape, trans, fixMe=False):
-    
-        tmp_trans = trans.split('|')[-1]
-        tmp_shapeName = tmp_trans + "Shape"
-        shape_lastName = shape.split("|")[-1]
+    @staticmethod
+    def FixName(trans):
+        return "{}Shape".format(trans)
 
-        if fixMe:
-            return shape.replace(shape_lastName, tmp_shapeName)
+    @staticmethod
+    def NameCompare(shape, trans):
+        return ("{}Shape".format(trans) == shape)
 
-        if tmp_shapeName != shape_lastName:
-            return False
-        else:
-            return True
 
 def Create():
     return ShapeNamedAfterTransform()


### PR DESCRIPTION
further testing on bigger sets revealed bugs.
freeze vertex: 
- sys.float_info.epsilon was too large, reduced the value to .0000001
- removed breaks and simply returned once the tweak case was True. 

intermediate node:
- node.dg().getConnections(plugs) will kFailure() when no connections exist

ShapeNamedAfterTransform:
psphere1
|_pshere1Shape
Checks for the above convention. 
