### PR TITLE
Remove dependency on destroyed

### DIFF
--- a/python/medicUI/functions.py
+++ b/python/medicUI/functions.py
@@ -2,7 +2,6 @@ from maya import OpenMaya
 from maya import OpenMayaUI
 from PySide2 import QtWidgets
 import shiboken2
-import sys
 
 
 BlankSelectionList = OpenMaya.MSelectionList()
@@ -17,14 +16,6 @@ def ClearSelection():
 
 def getMayaMainWindow():
     return shiboken2.wrapInstance(long(OpenMayaUI.MQtUtil.mainWindow()), QtWidgets.QMainWindow)
-
-
-def registSceneOpenCallback(function):
-    return OpenMaya.MEventMessage.addEventCallback("SceneOpened", function)
-
-
-def registNewSceneOpenCallback(function):
-    return OpenMaya.MEventMessage.addEventCallback("NewSceneOpened", function)
 
 
 def removeCallbacks(ids):

--- a/python/medicUI/functions.py
+++ b/python/medicUI/functions.py
@@ -3,7 +3,6 @@ from maya import OpenMayaUI
 from PySide2 import QtWidgets
 import shiboken2
 
-
 BlankSelectionList = OpenMaya.MSelectionList()
 if not hasattr(__builtins__, "long"):
     long = int
@@ -16,6 +15,14 @@ def ClearSelection():
 
 def getMayaMainWindow():
     return shiboken2.wrapInstance(long(OpenMayaUI.MQtUtil.mainWindow()), QtWidgets.QMainWindow)
+
+
+def registSceneOpenCallback(function):
+    return OpenMaya.MEventMessage.addEventCallback("SceneOpened", function)
+
+
+def registNewSceneOpenCallback(function):
+    return OpenMaya.MEventMessage.addEventCallback("NewSceneOpened", function)
 
 
 def removeCallbacks(ids):

--- a/python/medicUI/widgets.py
+++ b/python/medicUI/widgets.py
@@ -707,17 +707,6 @@ class MainWidget(QtWidgets.QWidget):
         self.__detail_widget.ReportsChanged.connect(self.__reportsChanged)
         self.__testers_widget.SingleTestTriggered.connect(self.__singleTest)
 
-        ## set maya event callback
-        self.__callback_ids.append(functions.registSceneOpenCallback(self.__sceneChanged))
-        self.__callback_ids.append(functions.registNewSceneOpenCallback(self.__sceneChanged))
-        self.destroyed.connect(self.__removeCallbacks)
-
-    def __removeCallbacks(self):
-        functions.removeCallbacks(self.__callback_ids)
-
-    def __sceneChanged(self, *args):
-        self.reset()
-
     def reset(self):
         karte_item = self.__kartes_widget.currentKarte()
         if karte_item:

--- a/python/medicUI/window.py
+++ b/python/medicUI/window.py
@@ -1,4 +1,5 @@
 from PySide2 import QtWidgets, QtCore
+from maya import cmds
 from . import widgets
 from . import model
 import os
@@ -17,6 +18,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.setWindowFlags(self.windowFlags() | QtCore.Qt.WindowStaysOnTopHint)
         self.__makeWidgets()
         self.__setStyleSheet()
+        self.__registJobs()
 
     def setKarte(self, karteName):
         if self.__main_widget.setKarte(karteName):
@@ -78,6 +80,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self.__top_widget.reset_button.clicked.connect(self.__main_widget.reset)
         self.__top_widget.test_button.clicked.connect(self.__main_widget.test)
         self.__main_widget.StatusChanged.connect(self.__top_widget.status_label.setStatus)
+
+    def __registJobs(self):
+        cmds.scriptJob(event=('NewSceneOpened', self.__main_widget.reset), parent=self.objectName())
+        cmds.scriptJob(event=('SceneOpened', self.__main_widget.reset), parent=self.objectName())
 
     def __next(self):
         self.__top_widget.next()


### PR DESCRIPTION
Because there are situations where it is not called.

When I closed MainWindow, .emit() was never called on MainWidget.destroyed.
Therefore, the registered MEventMessage would continue to be called each time the scene was opened, and MainWidget.reset() would be executed on the deleted C++ pointer, and ScriptEditor would report an error all the way until Maya was closed.

The error accumulates each time I open and close medicUI as follows.
// Error: RuntimeError: file ~~medic/py/medicUI/widgets.py line 419: Internal C++ object (PySide2.QtWidgets.QLabel) already deleted.
// Warning: Python callback failed
// Error: RuntimeError: file ~~medic/py/medicUI/widgets.py line 419: Internal C++ object (PySide2.QtWidgets.QLabel) already deleted.
// Warning: Python callback failed

Therefore, this pull request eliminates the dependency on destroyed.

In general, C++ can control when destructors are called, but in Python, destructors are called only by the garbage collector, and Python does not seem to work as expected when code that depends on destructors or destroyed is written.

If we were to consider a different method than the one in this pull request, we could use QWidget.closeEvent(QCloseEvent event) as a substitute.
