### PR TITLE
Add Splitter

### DIFF
--- a/python/medicUI/style.qss
+++ b/python/medicUI/style.qss
@@ -5,6 +5,16 @@ QWidget
     color: rgb(0, 0, 0);
 }
 
+QWidget#detail_tester_top
+{
+    background-color: transparent;
+}
+
+QWidget#detail_tester_bottom
+{
+    background-color: transparent;
+}
+
 QFrame#medic_top_bar
 {
     border-bottom: 1px solid gray;
@@ -271,5 +281,10 @@ QTextEdit#detail_tester_description
     color: rgb(175, 175, 175);
     font-size: 14px;
     border: none;
+    background: transparent;
+}
+
+QSplitter#detail_tester_splitter
+{
     background: transparent;
 }

--- a/python/medicUI/style.qss
+++ b/python/medicUI/style.qss
@@ -288,3 +288,8 @@ QSplitter#detail_tester_splitter
 {
     background: transparent;
 }
+
+QSplitter#phase_2_splitter
+{
+    background-color: rgb(227, 227, 227);
+}

--- a/python/medicUI/widgets.py
+++ b/python/medicUI/widgets.py
@@ -715,7 +715,7 @@ class MainWidget(QtWidgets.QWidget):
         h_splitter.setChildrenCollapsible(False)
         h_splitter.addWidget(self.__testers_widget)
         h_splitter.addWidget(self.__detail_widget)
-        self.__phase_widgets[1] = [self.__testers_widget, self.__detail_widget]
+        self.__phase_widgets[1] = [h_splitter]
         main_layout.addWidget(h_splitter)
 
         ## signal

--- a/python/medicUI/widgets.py
+++ b/python/medicUI/widgets.py
@@ -711,6 +711,7 @@ class MainWidget(QtWidgets.QWidget):
 
         ## phase 2
         h_splitter = QtWidgets.QSplitter(QtCore.Qt.Horizontal)
+        h_splitter.setObjectName("phase_2_splitter")
         h_splitter.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
         h_splitter.setChildrenCollapsible(False)
         h_splitter.addWidget(self.__testers_widget)

--- a/python/medicUI/widgets.py
+++ b/python/medicUI/widgets.py
@@ -378,6 +378,17 @@ class TesterDetailWidget(QtWidgets.QWidget):
         self.__qt_parameter_layout = QtWidgets.QVBoxLayout()
         button_layout = QtWidgets.QHBoxLayout()
 
+        # splitter
+        v_splitter = QtWidgets.QSplitter(QtCore.Qt.Vertical)
+        v_splitter.setObjectName("detail_tester_splitter")
+        v_splitter.setChildrenCollapsible(False)
+        top_widget = QtWidgets.QWidget()
+        top_widget.setObjectName("detail_tester_top")
+        bottom_widget = QtWidgets.QWidget()
+        bottom_widget.setObjectName("detail_tester_bottom")
+        top_layout = QtWidgets.QVBoxLayout(top_widget)
+        bottom_layout = QtWidgets.QVBoxLayout(bottom_widget)
+
         # widgets
         self.__qt_tester_label = QtWidgets.QLabel()
         self.__qt_description = QtWidgets.QTextEdit()
@@ -397,12 +408,16 @@ class TesterDetailWidget(QtWidgets.QWidget):
         button_layout.addWidget(self.__qt_fix_selected_button)
         button_layout.addWidget(self.__qt_fix_all_button)
 
-        frame_layout.addWidget(self.__qt_tester_label)
-        frame_layout.addSpacing(20)
-        frame_layout.addWidget(self.__qt_description)
-        frame_layout.addWidget(self.__qt_report_list)
-        frame_layout.addLayout(self.__qt_parameter_layout)
-        frame_layout.addLayout(button_layout)
+        top_layout.addWidget(self.__qt_tester_label)
+        top_layout.addItem(QtWidgets.QSpacerItem(20, 20))
+        top_layout.addWidget(self.__qt_description)
+        bottom_layout.addWidget(self.__qt_report_list)
+        bottom_layout.addLayout(self.__qt_parameter_layout)
+        bottom_layout.addLayout(button_layout)
+
+        v_splitter.addWidget(top_widget)
+        v_splitter.addWidget(bottom_widget)
+        frame_layout.addWidget(v_splitter)
 
         self.__qt_fix_all_button.clicked.connect(self.__fixAll)
         self.__qt_fix_selected_button.clicked.connect(self.__fixSelected)
@@ -695,11 +710,13 @@ class MainWidget(QtWidgets.QWidget):
         self.__phase_widgets[0] = [self.__kartes_widget, self.__karte_toggle]
 
         ## phase 2
-        h_layout = QtWidgets.QHBoxLayout()
-        h_layout.addWidget(self.__testers_widget)
-        h_layout.addWidget(self.__detail_widget)
+        h_splitter = QtWidgets.QSplitter(QtCore.Qt.Horizontal)
+        h_splitter.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+        h_splitter.setChildrenCollapsible(False)
+        h_splitter.addWidget(self.__testers_widget)
+        h_splitter.addWidget(self.__detail_widget)
         self.__phase_widgets[1] = [self.__testers_widget, self.__detail_widget]
-        main_layout.addLayout(h_layout)
+        main_layout.addWidget(h_splitter)
 
         ## signal
         self.__kartes_widget.KarteChanged.connect(self.__karteChanged)


### PR DESCRIPTION
Added a QSplitter between TesterList and TesterDetail.
This is because we wanted to be able to expand the window size even if it is not linked to the window size of the TesterDetail.

Added QSplitter to TesterDetail as well.
This is because it is difficult to read from the small window, especially when long sentences are entered in the description of the tester.

We set two QSplitters because we believe that the Description is an important UI for both of them.
I believe that having a detailed specification in the Description to understand the Tester's specifications will reduce a lot of communication costs.
However, with the original UI, it was difficult to expand the Description area enough to read long sentences, so we tried to make the Description area expandable by the artist himself using QSplitter.