### PR TITLE
Added font settings for Windows, specifying the same fonts as in Maya

### DIFF
--- a/python/medicUI/style.qss
+++ b/python/medicUI/style.qss
@@ -1,6 +1,6 @@
 QWidget
 {
-    font-family: Helvetica;
+    font-family: "Segoe UI", Helvetica;
     background-color: rgb(255, 255, 255);
     color: rgb(0, 0, 0);
 }


### PR DESCRIPTION
Since Helvetica fonts are not installed on standard Windows, the fonts appeared to be corrupted.
Therefore, we specified the same font used for Maya's UI on Windows.
This will make the text very readable for Windows medic users.

I don't know if the display will be different on macOS since we don't have a macOS environment to test it here.
It may be better to specify Helvetica first (to the left).