### PR TITLE
Pascal case to space separated

### DIFF
--- a/python/medicUI/delegate.py
+++ b/python/medicUI/delegate.py
@@ -3,7 +3,7 @@ from PySide2 import QtCore
 from PySide2 import QtGui
 import os
 from . import model
-
+from . import functions
 
 IconDir = os.path.abspath(os.path.join(__file__, "../icons"))
 
@@ -49,6 +49,7 @@ class KarteDelegate(ListItemDelegate):
         rect = option.rect
         font_matrics = QtGui.QFontMetrics(option.font)
         karte_name = index.data(model.DisplayRole)
+        karte_name = functions.pascal_case_to_space_separated(karte_name)
 
         painter.fillRect(rect, self.getBackgroudColor(option, index))
         painter.drawPixmap(QtCore.QRect(rect.x() + 10, rect.y(), 50, 50), self.__karte_icon)
@@ -72,6 +73,7 @@ class TesterDelegate(ListItemDelegate):
         rect = option.rect
         font_matrics = QtGui.QFontMetrics(option.font)
         tester_name = index.data(model.DisplayRole)
+        tester_name = functions.pascal_case_to_space_separated(tester_name)
 
         status = index.data(model.StatusRole)
         if status == model.Ready:

--- a/python/medicUI/functions.py
+++ b/python/medicUI/functions.py
@@ -2,7 +2,9 @@ from maya import OpenMaya
 from maya import OpenMayaUI
 from PySide2 import QtWidgets
 import shiboken2
+import re
 
+FIND_PASCAL_CASE = re.compile(r'[A-Z0-9][a-z0-9]+')
 BlankSelectionList = OpenMaya.MSelectionList()
 if not hasattr(__builtins__, "long"):
     long = int
@@ -28,3 +30,10 @@ def registNewSceneOpenCallback(function):
 def removeCallbacks(ids):
     for id in ids:
         OpenMaya.MMessage.removeCallback(id)
+
+
+def pascal_case_to_space_separated(string: str) -> str:
+    if any(char in string for char in '_-+=/ !@#$%^&*(){}[]|\\~`:;"\'<>'):
+        # This is surely not PascalCase.
+        return string
+    return ' '.join(FIND_PASCAL_CASE.findall(string))

--- a/python/medicUI/widgets.py
+++ b/python/medicUI/widgets.py
@@ -350,7 +350,7 @@ class TesterDetailWidget(QtWidgets.QWidget):
         self.__setReportItems(self.__tester_item.reports())
 
     def __setTester(self, testerItem):
-        self.__setTesterName(testerItem.name())
+        self.__setTesterName(functions.pascal_case_to_space_separated(testerItem.name()))
         self.__setDescription(testerItem.description())
         self.__clearParameters()
         self.__setParameters(testerItem.parameters())


### PR DESCRIPTION
When looking at the attribute names in Maya's Attribute Editor, I noticed they're in PascalCase. Yet, the added spaces between words make them quite approachable and easy on the eyes. It got me thinking: wouldn't it be lovely if the medic UI adopted this style too? So, I went ahead and brought that same readability to it.