### PR TITLE
Corresponds to monitor magnification ratio

### DIFF
--- a/python/medicUI/delegate.py
+++ b/python/medicUI/delegate.py
@@ -3,7 +3,7 @@ from PySide2 import QtCore
 from PySide2 import QtGui
 import os
 from . import model
-
+from . import functions
 
 IconDir = os.path.abspath(os.path.join(__file__, "../icons"))
 
@@ -34,10 +34,14 @@ class ReportDelegate(ListItemDelegate):
         report_name = index.data(model.DisplayRole)
 
         painter.fillRect(rect, self.getBackgroudColor(option, index))
-        painter.drawText(rect.x() + 5, rect.y() + 15, report_name)
+        painter.drawText(rect.x() + functions.applyMonitorScalingTo(5),
+                         rect.y() + functions.applyMonitorScalingTo(15),
+                         report_name)
 
         painter.restore()
 
+    def sizeHint(self, option, index):
+        return QtCore.QSize(option.decorationSize.width(), functions.applyMonitorScalingTo(22))
 
 class KarteDelegate(ListItemDelegate):
     def __init__(self, parent=None):
@@ -51,13 +55,20 @@ class KarteDelegate(ListItemDelegate):
         karte_name = index.data(model.DisplayRole)
 
         painter.fillRect(rect, self.getBackgroudColor(option, index))
-        painter.drawPixmap(QtCore.QRect(rect.x() + 10, rect.y(), 50, 50), self.__karte_icon)
-        painter.drawText(rect.x() + 80, rect.y() + rect.height() * 0.5 + font_matrics.height() * 0.5 - 4, karte_name)
+        painter.drawPixmap(QtCore.QRect(rect.x() + functions.applyMonitorScalingTo(10),
+                                        rect.y(),
+                                        functions.applyMonitorScalingTo(50),
+                                        functions.applyMonitorScalingTo(50)),
+                           self.__karte_icon)
+        painter.drawText(rect.x() + functions.applyMonitorScalingTo(80),
+                         rect.y() + rect.height() * 0.5 + font_matrics.height() * 0.5 - functions.applyMonitorScalingTo(
+                             4),
+                         karte_name)
 
         painter.restore()
 
     def sizeHint(self, option, index):
-        return QtCore.QSize(option.decorationSize.width(), 50)
+        return QtCore.QSize(option.decorationSize.width(), functions.applyMonitorScalingTo(50))
 
 
 class TesterDelegate(ListItemDelegate):
@@ -82,10 +93,16 @@ class TesterDelegate(ListItemDelegate):
             icon = self.__failure_icon
 
         painter.fillRect(rect, self.getBackgroudColor(option, index))
-        painter.drawPixmap(QtCore.QRect(rect.x() + 12, rect.y() + 2, 16, 16), icon)
-        painter.drawText(rect.x() + 40, rect.y() + rect.height() * 0.5 + font_matrics.height() * 0.5 - 4, tester_name)
+        painter.drawPixmap(QtCore.QRect(rect.x() + functions.applyMonitorScalingTo(12),
+                                        rect.y() + functions.applyMonitorScalingTo(3),
+                                        functions.applyMonitorScalingTo(16),
+                                        functions.applyMonitorScalingTo(16)),
+                           icon)
+        painter.drawText(rect.x() + functions.applyMonitorScalingTo(40),
+                         rect.y() + rect.height() * 0.5 + font_matrics.height() * 0.5 - functions.applyMonitorScalingTo(2),
+                         tester_name)
 
         painter.restore()
 
     def sizeHint(self, option, index):
-        return QtCore.QSize(option.decorationSize.width(), 20)
+        return QtCore.QSize(option.decorationSize.width(), functions.applyMonitorScalingTo(22))

--- a/python/medicUI/functions.py
+++ b/python/medicUI/functions.py
@@ -1,6 +1,7 @@
 from maya import OpenMaya
 from maya import OpenMayaUI
 from PySide2 import QtWidgets
+from PySide2.QtGui import QGuiApplication
 import shiboken2
 
 BlankSelectionList = OpenMaya.MSelectionList()
@@ -28,3 +29,17 @@ def registNewSceneOpenCallback(function):
 def removeCallbacks(ids):
     for id in ids:
         OpenMaya.MMessage.removeCallback(id)
+
+
+def getMoniterScalingFactor() -> float:
+    screen = QGuiApplication.primaryScreen()
+    if screen:
+        return screen.logicalDotsPerInch() / 96.0
+    return 1.0
+
+
+MONITOR_SCALING_FACTOR = getMoniterScalingFactor()
+
+
+def applyMonitorScalingTo(value: int | float) -> int:
+    return int(value * MONITOR_SCALING_FACTOR)

--- a/python/medicUI/scale_style.json
+++ b/python/medicUI/scale_style.json
@@ -1,0 +1,19 @@
+{
+  "QLabel_font_size": 18,
+  "QLabel_margin_right": 20,
+  "QLabel_status_label_font_size": 14,
+  "QLabel_parameter_label_font_size": 12,
+  "QPushButton_width": 24,
+  "QPushButton_height": 24,
+  "QPushButton_medic_browser_back_border_radius": 4,
+  "QPushButton_medic_browser_next_border_radius": 4,
+  "QPushButton_detail_button_border_radius": 5,
+  "QPushButton_detail_button_font_size": 11,
+  "QListView_medic_tester_list_font_size": 12,
+  "QListView_medic_karte_list_font_size": 18,
+  "QListView_detail_report_list_font_size": 12,
+  "QListView_detail_report_list_border_radius": 5,
+  "QListView_detail_report_list_padding": 5,
+  "QListView_detail_report_list_height": 22,
+  "QTextEdit_detail_tester_description_font_size": 14
+}

--- a/python/medicUI/style.qss
+++ b/python/medicUI/style.qss
@@ -34,14 +34,14 @@ QFrame#medic_top_bar, QFrame#medic_browser_buttons_widget
 QLabel
 {
     color: rgb(53, 53, 53);
-    margin-right: 20px;
-    font-size: 18px;
+    margin-right: ${QLabel_margin_right}px;
+    font-size: ${QLabel_font_size}px;
     background-color: rgb(235, 235, 235);
 }
 
 QLabel#status_label
 {
-    font-size: 14px;
+    font-size: ${QLabel_status_label_font_size}px;
 }
 
 QLabel#detail_tester_label
@@ -52,14 +52,14 @@ QLabel#detail_tester_label
 QLabel#parameter_label
 {
     background: transparent;
-    font-size: 12px;
+    font-size: ${QLabel_parameter_label_font_size}px;
 }
 
 QPushButton
 {
     color: rgb(140, 140, 140);
-    width: 24px;
-    height: 24px;
+    width: ${QPushButton_width}px;
+    height: ${QPushButton_height}px;
 }
 
 QPushButton#medic_browser_back
@@ -67,7 +67,7 @@ QPushButton#medic_browser_back
     background-color: rgb(246, 246, 246);
     border-style: solid;
     border-width: 0.5px;
-    border-radius: 4px;
+    border-radius: ${QPushButton_medic_browser_back_border_radius}px;
     border-color: rgb(199, 199, 199);
     image: url("icons/backOn.png");
 }
@@ -82,7 +82,7 @@ QPushButton#medic_browser_next
     background-color: rgb(246, 246, 246);
     border-style: solid;
     border-width: 0.5px;
-    border-radius: 4px;
+    border-radius: ${QPushButton_medic_browser_next_border_radius}px;
     border-color: rgb(199, 199, 199);
     image: url("icons/nextOn.png");
 }
@@ -138,9 +138,9 @@ QPushButton#test_button::pressed
 
 QPushButton#detail_button
 {
-    font-size: 11px;
+    font-size: ${QPushButton_detail_button_font_size}px;
     border: 1px solid rgb(100, 100, 100);
-    border-radius: 5px;
+    border-radius: ${QPushButton_detail_button_border_radius}px;
     background-color: rgb(255, 255, 255);
     color: rgb(0, 12, 20);
 }
@@ -254,32 +254,27 @@ QListView
 
 QListView#medic_tester_list
 {
-    font-size: 12px;
+    font-size: ${QListView_medic_tester_list_font_size}px;
 }
 
 QListView#medic_karte_list
 {
-    font-size: 18px;
+    font-size: ${QListView_medic_karte_list_font_size}px;
 }
 
-QListView#detial_report_list
+QListView#detail_report_list
 {
-    font-size: 12px;
+    font-size: ${QListView_detail_report_list_font_size}px;
     border: none;
-    border-radius: 5px;
-    padding: 5px;
-    height: 20px;
-}
-
-QListView#detial_report_list::item
-{
-    height: 18px;
+    border-radius: ${QListView_detail_report_list_border_radius}px;
+    padding: ${QListView_detail_report_list_padding}px;
+    height: ${QListView_detail_report_list_height}px;
 }
 
 QTextEdit#detail_tester_description
 {
     color: rgb(175, 175, 175);
-    font-size: 14px;
+    font-size: ${QTextEdit_detail_tester_description_font_size}px;
     border: none;
     background: transparent;
 }
@@ -289,7 +284,7 @@ QSplitter#detail_tester_splitter
     background: transparent;
 }
 
-QSplitter#phase_2_splitter
+QSplitter#phase2_splitter
 {
     background-color: rgb(227, 227, 227);
 }

--- a/python/medicUI/widgets.py
+++ b/python/medicUI/widgets.py
@@ -124,7 +124,7 @@ class StatusLabel(QtWidgets.QLabel):
     def __init__(self, parent=None):
         super(StatusLabel, self).__init__(parent=parent)
         self.setObjectName("status_label")
-        self.setFixedWidth(80)
+        self.setFixedWidth(functions.applyMonitorScalingTo(80))
         self.__ready_icon = QtGui.QPixmap(os.path.join(IconDir, "success.png")).scaled(16, 16)
         self.__success_icon = QtGui.QPixmap(os.path.join(IconDir, "success.png")).scaled(16, 16)
         self.__failure_icon = QtGui.QPixmap(os.path.join(IconDir, "failure.png")).scaled(16, 16)
@@ -391,8 +391,8 @@ class TesterDetailWidget(QtWidgets.QWidget):
 
         # widgets
         self.__qt_tester_label = QtWidgets.QLabel()
+        self.__qt_tester_label.setFixedHeight(functions.applyMonitorScalingTo(20))
         self.__qt_description = QtWidgets.QTextEdit()
-        self.__qt_description.setFixedHeight(50)
         self.__qt_description.setReadOnly(True)
         self.__qt_tester_label.setObjectName("detail_tester_label")
         self.__qt_description.setObjectName("detail_tester_description")

--- a/python/medicUI/window.py
+++ b/python/medicUI/window.py
@@ -1,8 +1,10 @@
 from PySide2 import QtWidgets, QtCore
 from maya import cmds
 from . import widgets
-from . import model
+from . import functions
 import os
+import json
+import string
 
 
 class MainWindow(QtWidgets.QMainWindow):
@@ -42,15 +44,21 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def __setStyleSheet(self):
         qss_path = os.path.abspath(os.path.join(__file__, "../style.qss"))
+        scale_style_path = os.path.abspath(os.path.join(__file__, "../scale_style.json"))
 
-        if not os.path.isfile(qss_path):
+        if not os.path.isfile(qss_path) or not os.path.isfile(scale_style_path):
             return
 
         current_dir = os.path.dirname(__file__)
 
-        style = ""
+        with open(scale_style_path, "r") as f:
+            scale_style_data = json.load(f)
+            scale_style_data = {k: functions.applyMonitorScalingTo(v)
+                                for k, v in scale_style_data.items()}
+
         with open(qss_path, "r") as f:
-            style = f.read()
+            template = string.Template(f.read())
+            style = template.safe_substitute(scale_style_data)
             style = style.replace('url("', 'url("%s/' % current_dir.replace("\\", "/"))
 
         self.setStyleSheet(style)


### PR DESCRIPTION
I tried to correspond to the monitor magnification rate.
Maya seems to acquire the monitor magnification rate of the main monitor only when Maya starts up, and expands the UI according to the monitor magnification rate, so I implemented it in the same way.
Even if the window is moved to a monitor with a different monitor magnification rate after startup, the magnification rate is not changed.